### PR TITLE
add HEAD method for dry-run

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "quoteProps": "as-needed",
+  "singleQuote": true,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "printWidth": 65,
+  "arrowParens": "avoid"
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -6,7 +6,7 @@ const key = (hash: string) => `artifact:${hash}`;
 // See https://developers.cloudflare.com/workers/cli-wrangler/commands#secret
 declare var SECRET_KEY: string;
 
-addEventListener("fetch", (event) => {
+addEventListener('fetch', event => {
   const { request } = event;
   const url = new URL(request.url);
 
@@ -14,61 +14,71 @@ addEventListener("fetch", (event) => {
   const match = url.pathname.match(storageRoutePattern);
 
   if (!match) {
-    return void event.respondWith(new Response(null, { status: 404 }));
-  }
-
-  if (request.headers.get("Authorization") !== `Bearer ${SECRET_KEY}`) {
     return void event.respondWith(
-      new Response("Request not permitted", { status: 401 })
+      new Response(null, { status: 404 }),
+    );
+  }
+  // prettier-ignore
+  if (request.headers.get('Authorization') !== `Bearer ${SECRET_KEY}`) {
+    return void event.respondWith(
+      new Response('Request not permitted', { status: 401 }),
     );
   }
 
   const { hash } = match.groups!;
 
   switch (request.method) {
-    case "GET": {
-      return void event.respondWith(getArtifact(hash));
+    case 'GET': {
+      // prettier-ignore
+      return void event.respondWith(
+        getArtifact(hash),
+      );
     }
 
-    case "HEAD": {
-      return void event.respondWith(getArtifact(hash));
+    case 'HEAD': {
+      // prettier-ignore
+      return void event.respondWith(
+        getArtifact(hash),
+      );
     }
 
-    case "PUT": {
+    case 'PUT': {
       if (!request.body) {
+        // prettier-ignore
         return void event.respondWith(
-          new Response("Request body cannot be empty", { status: 400 })
+          new Response('Request body cannot be empty', { status: 400 }),
         );
       }
-      return void event.respondWith(putArtifact(hash, request.body));
+      return void event.respondWith(
+        putArtifact(hash, request.body),
+      );
     }
 
     default: {
       return void event.respondWith(
-        new Response("Method not allowed", { status: 405 })
+        new Response('Method not allowed', { status: 405 }),
       );
     }
   }
 });
 
+// prettier-ignore
 async function getArtifact(hash: string): Promise<Response> {
-  const artifact = await STORAGE.get(key(hash), "stream");
+  const artifact = await STORAGE.get(key(hash), 'stream');
   if (artifact) {
     return new Response(artifact);
   } else {
-    return new Response("Artifact not found", { status: 404 });
+    return new Response('Artifact not found', { status: 404 });
   }
 }
 
-async function putArtifact(
-  hash: string,
-  artifact: ReadableStream
-): Promise<Response> {
+// prettier-ignore
+async function putArtifact(hash: string, artifact: ReadableStream,): Promise<Response> {
   try {
     await STORAGE.put(key(hash), artifact);
     return new Response(null, { status: 204 });
   } catch (e) {
     console.error(e);
-    return new Response("Failed to store artifact", { status: 500 });
+    return new Response('Failed to store artifact', { status: 500 });
   }
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -6,7 +6,7 @@ const key = (hash: string) => `artifact:${hash}`;
 // See https://developers.cloudflare.com/workers/cli-wrangler/commands#secret
 declare var SECRET_KEY: string;
 
-addEventListener('fetch', event => {
+addEventListener("fetch", (event) => {
   const { request } = event;
   const url = new URL(request.url);
 
@@ -14,60 +14,61 @@ addEventListener('fetch', event => {
   const match = url.pathname.match(storageRoutePattern);
 
   if (!match) {
-    return void event.respondWith(
-      new Response(null, { status: 404 }),
-    );
+    return void event.respondWith(new Response(null, { status: 404 }));
   }
 
-  if (request.headers.get('Authorization') !== `Bearer ${SECRET_KEY}`) {
+  if (request.headers.get("Authorization") !== `Bearer ${SECRET_KEY}`) {
     return void event.respondWith(
-      new Response('Request not permitted', { status: 401 }),
+      new Response("Request not permitted", { status: 401 })
     );
   }
 
   const { hash } = match.groups!;
 
   switch (request.method) {
-    case 'GET': {
-      return void event.respondWith(
-        getArtifact(hash),
-      );
+    case "GET": {
+      return void event.respondWith(getArtifact(hash));
     }
 
-    case 'PUT': {
+    case "HEAD": {
+      return void event.respondWith(getArtifact(hash));
+    }
+
+    case "PUT": {
       if (!request.body) {
         return void event.respondWith(
-          new Response('Request body cannot be empty', { status: 400 }),
+          new Response("Request body cannot be empty", { status: 400 })
         );
       }
-      return void event.respondWith(
-        putArtifact(hash, request.body),
-      );
+      return void event.respondWith(putArtifact(hash, request.body));
     }
 
     default: {
       return void event.respondWith(
-        new Response('Method not allowed', { status: 405 }),
+        new Response("Method not allowed", { status: 405 })
       );
     }
   }
 });
 
 async function getArtifact(hash: string): Promise<Response> {
-  const artifact = await STORAGE.get(key(hash), 'stream');
+  const artifact = await STORAGE.get(key(hash), "stream");
   if (artifact) {
     return new Response(artifact);
   } else {
-    return new Response('Artifact not found', { status: 404 });
+    return new Response("Artifact not found", { status: 404 });
   }
 }
 
-async function putArtifact(hash: string, artifact: ReadableStream): Promise<Response> {
+async function putArtifact(
+  hash: string,
+  artifact: ReadableStream
+): Promise<Response> {
   try {
     await STORAGE.put(key(hash), artifact);
     return new Response(null, { status: 204 });
   } catch (e) {
     console.error(e);
-    return new Response('Failed to store artifact', { status: 500 });
+    return new Response("Failed to store artifact", { status: 500 });
   }
 }


### PR DESCRIPTION
As of turbo 1.5.2, the --dry-run option checks the cache for the artefacts.


This PR lets the worker respond to the HEAD http method